### PR TITLE
xgboost<1 needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests
 pandas
-scikit-learn==0.19.0
-xgboost
+scikit-learn<0.23
+xgboost<1
 joblib
 depedit


### PR DESCRIPTION
With `xgboost` 1.0.0 and later I've got an error message below:

> If you are loading a serialized model (like pickle in Python, RDS in R) generated by older XGBoost, please export the model by calling `Booster.save_model` from that version first, then load it back in current version.

And I can use `scikit-learn` 0.22, but `scikit-learn` 0.23 does not have `joblib` at

```
from sklearn.externals import joblib
```